### PR TITLE
specify maximum dpi for nvidia QSpinBox

### DIFF
--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -720,7 +720,7 @@
              <item>
               <widget class="QSpinBox" name="nvidiaDpiSpinBox">
                <property name="maximum">
-                <number>65535</number>
+                <number>1000</number>
                </property>
               </widget>
              </item>

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -718,7 +718,11 @@
               </widget>
              </item>
              <item>
-              <widget class="QSpinBox" name="nvidiaDpiSpinBox"/>
+              <widget class="QSpinBox" name="nvidiaDpiSpinBox">
+               <property name="maximum">
+                <number>65535</number>
+               </property>
+              </widget>
              </item>
              <item>
               <spacer name="nvidiaDpiSpacer">


### PR DESCRIPTION
## What did I do?
Set nvidia dpi's QSpinBox maximum number to 65535.

## Why?
You use QSpinBox in nvidia dpi setting, but doesn't set a maximum value, according to [Qt5's document](https://doc.qt.io/Qt-5/qspinbox.html#maximum-prop), the default maximum value is 99. Thus, I cannot set dpi larger than 99. However, it is quite common to have a dpi larger than 99... So, I think this is a bug.