### PR TITLE
Fix typo & update translation

### DIFF
--- a/data/translations/optimus-manager.ts
+++ b/data/translations/optimus-manager.ts
@@ -5,7 +5,7 @@
     <name>AppSettings</name>
     <message>
         <location filename="../../src/appsettings.cpp" line="71"/>
-        <source>Unable to create autorun file from </source>
+        <source>Unable to create autorun file from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -207,12 +207,12 @@ You can install bbswitch for the default kernel with &quot;sudo pacman -S bbswit
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="751"/>
+        <location filename="../../src/settingsdialog.ui" line="755"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to enable the NVreg_UsePageAttributeTable option in the Nvidia driver &lt;span style=&quot; font-style:italic;&quot;&gt;Recommended&lt;/span&gt;, can cause poor CPU performance otherwise&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="764"/>
+        <location filename="../../src/settingsdialog.ui" line="768"/>
         <source>Overclocking options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -345,40 +345,40 @@ You can install bbswitch for the default kernel with &quot;sudo pacman -S bbswit
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="741"/>
+        <location filename="../../src/settingsdialog.ui" line="745"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to enable modesetting&lt;/p&gt;&lt;p&gt;Required for PRIME Synchronization&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="761"/>
+        <location filename="../../src/settingsdialog.ui" line="765"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable CoolBits in the Xorg configuration and unlock clocking options in the Nvidia control panel&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="771"/>
+        <location filename="../../src/settingsdialog.ui" line="775"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable triple buffering&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="774"/>
-        <source>Tripple buffer</source>
+        <location filename="../../src/settingsdialog.ui" line="778"/>
+        <source>Triple buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="831"/>
-        <location filename="../../src/settingsdialog.ui" line="962"/>
+        <location filename="../../src/settingsdialog.ui" line="835"/>
+        <location filename="../../src/settingsdialog.ui" line="966"/>
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="845"/>
-        <location filename="../../src/settingsdialog.ui" line="939"/>
+        <location filename="../../src/settingsdialog.ui" line="849"/>
+        <location filename="../../src/settingsdialog.ui" line="943"/>
         <source>Autor:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="852"/>
-        <location filename="../../src/settingsdialog.ui" line="976"/>
+        <location filename="../../src/settingsdialog.ui" line="856"/>
+        <location filename="../../src/settingsdialog.ui" line="980"/>
         <source>License:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/translations/optimus-manager_ru.ts
+++ b/data/translations/optimus-manager_ru.ts
@@ -4,9 +4,13 @@
 <context>
     <name>AppSettings</name>
     <message>
-        <location filename="../../src/appsettings.cpp" line="71"/>
         <source>Unable to create autorun file from </source>
-        <translation>Не удалось создать файл автозапуска из </translation>
+        <translation type="vanished">Не удалось создать файл автозапуска из </translation>
+    </message>
+    <message>
+        <location filename="../../src/appsettings.cpp" line="71"/>
+        <source>Unable to create autorun file from &apos;%1&apos;</source>
+        <translation>Не удалось создать файл автозапуска из &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -213,12 +217,12 @@ You can install bbswitch for the default kernel with &quot;sudo pacman -S bbswit
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это будет установлено с помощью скрипта Xsetup, который передается вашему менеджеру входа&lt;br/&gt;Он запускает команду&lt;/p&gt;&lt;p&gt;xrandr --dpi &amp;lt;dpi value&amp;gt;&lt;/p&gt;&lt;p&gt;Оставьте 0 для значения по умолчанию&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="751"/>
+        <location filename="../../src/settingsdialog.ui" line="755"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to enable the NVreg_UsePageAttributeTable option in the Nvidia driver &lt;span style=&quot; font-style:italic;&quot;&gt;Recommended&lt;/span&gt;, can cause poor CPU performance otherwise&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включить или нет параметр NVreg_UsePageAttributeTable в драйвере Nvidia&lt;span style=&quot; font-style:italic;&quot;&gt;Рекомендуется&lt;/span&gt;, в противном случае может привести к снижению производительности процессора&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="764"/>
+        <location filename="../../src/settingsdialog.ui" line="768"/>
         <source>Overclocking options</source>
         <translation>Опции разгона</translation>
     </message>
@@ -346,40 +350,44 @@ You can install bbswitch for the default kernel with &quot;sudo pacman -S bbswit
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включение или отключение modesettings для драйвера nouveau&lt;/p&gt;&lt;p&gt;Не влияет на modesetting для драйвера Intel GPU&lt;/p&gt;&lt;p&gt;Эта опция несовместима с bbswitch и будет игнорироваться, если он включен&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="741"/>
+        <location filename="../../src/settingsdialog.ui" line="745"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether or not to enable modesetting&lt;/p&gt;&lt;p&gt;Required for PRIME Synchronization&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включить или нет modesetting&lt;/p&gt;&lt;p&gt;Требуется для синхронизации PRIME&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="761"/>
+        <location filename="../../src/settingsdialog.ui" line="765"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable CoolBits in the Xorg configuration and unlock clocking options in the Nvidia control panel&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включить CoolBits в конфигурации Xorg и разблокировать опции разгона в панели управления Nvidia&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="771"/>
+        <location filename="../../src/settingsdialog.ui" line="775"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable triple buffering&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Включить тройную буферизацию&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="774"/>
-        <source>Tripple buffer</source>
+        <location filename="../../src/settingsdialog.ui" line="778"/>
+        <source>Triple buffer</source>
         <translation>Тройная буферизация</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="831"/>
-        <location filename="../../src/settingsdialog.ui" line="962"/>
+        <source>Tripple buffer</source>
+        <translation type="vanished">Тройная буферизация</translation>
+    </message>
+    <message>
+        <location filename="../../src/settingsdialog.ui" line="835"/>
+        <location filename="../../src/settingsdialog.ui" line="966"/>
         <source>Version:</source>
         <translation>Версия:</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="845"/>
-        <location filename="../../src/settingsdialog.ui" line="939"/>
+        <location filename="../../src/settingsdialog.ui" line="849"/>
+        <location filename="../../src/settingsdialog.ui" line="943"/>
         <source>Autor:</source>
         <translation>Автор:</translation>
     </message>
     <message>
-        <location filename="../../src/settingsdialog.ui" line="852"/>
-        <location filename="../../src/settingsdialog.ui" line="976"/>
+        <location filename="../../src/settingsdialog.ui" line="856"/>
+        <location filename="../../src/settingsdialog.ui" line="980"/>
         <source>License:</source>
         <translation>Лицензия:</translation>
     </message>

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -68,7 +68,7 @@ void AppSettings::setAutostartEnabled(bool enabled)
             constexpr char desktopFileName[] = "/usr/share/applications/optimus-manager-qt.desktop";
 
             if (!QFile::copy(desktopFileName, autorunFile.fileName()))
-                qCritical() << tr("Unable to create autorun file from ") + desktopFileName;
+                qCritical() << tr("Unable to create autorun file from '%1'").arg(desktopFileName);
         }
     } else {
         // Remove autorun file

--- a/src/optimussettings.cpp
+++ b/src/optimussettings.cpp
@@ -387,7 +387,7 @@ OptimusSettings::NvidiaOptions OptimusSettings::nvidiaOptions() const
     if (optionsStrings.contains("overclocking"))
         options |= Overclocking;
     if (optionsStrings.contains("triple_buffer"))
-        options |= TrippleBuffer;
+        options |= TripleBuffer;
 
     return options;
 }
@@ -399,7 +399,7 @@ void OptimusSettings::setNvidiaOptions(NvidiaOptions options)
     if (options.testFlag(Overclocking))
         optionsStrings.append("overclocking");
 
-    if (options.testFlag(TrippleBuffer))
+    if (options.testFlag(TripleBuffer))
         optionsStrings.append("triple_buffer");
 
     m_settings->setValue("nvidia/options", optionsStrings);

--- a/src/optimussettings.h
+++ b/src/optimussettings.h
@@ -62,7 +62,7 @@ public:
     Q_ENUM(DRI)
     enum NvidiaOption {
         Overclocking = 1,
-        TrippleBuffer = 2
+        TripleBuffer = 2
     };
     Q_DECLARE_FLAGS(NvidiaOptions, NvidiaOption)
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -107,7 +107,7 @@ void SettingsDialog::on_SettingsDialog_accepted()
 
     OptimusSettings::NvidiaOptions nvidiaOptions;
     nvidiaOptions.setFlag(OptimusSettings::Overclocking, ui->nvidiaOverclockingCheckBox->isChecked());
-    nvidiaOptions.setFlag(OptimusSettings::TrippleBuffer, ui->nvidiaTrippleBuffercheckBox->isChecked());
+    nvidiaOptions.setFlag(OptimusSettings::TripleBuffer, ui->nvidiaTripleBuffercheckBox->isChecked());
     optimusSettings.setNvidiaOptions(nvidiaOptions);
 
     optimusSettings.apply();
@@ -146,7 +146,7 @@ void SettingsDialog::restoreDefaults()
     ui->nvidiaModesetCheckBox->setChecked(true);
     ui->nvidiaPatCheckBox->setChecked(true);
     ui->nvidiaOverclockingCheckBox->setChecked(true);
-    ui->nvidiaTrippleBuffercheckBox->setChecked(false);
+    ui->nvidiaTripleBuffercheckBox->setChecked(false);
 }
 
 void SettingsDialog::loadSettings()
@@ -185,7 +185,7 @@ void SettingsDialog::loadSettings()
 
     const OptimusSettings::NvidiaOptions nvidiaOptions = optimusSettings.nvidiaOptions();
     ui->nvidiaOverclockingCheckBox->setChecked(nvidiaOptions.testFlag(OptimusSettings::Overclocking));
-    ui->nvidiaTrippleBuffercheckBox->setChecked(nvidiaOptions.testFlag(OptimusSettings::TrippleBuffer));
+    ui->nvidiaTripleBuffercheckBox->setChecked(nvidiaOptions.testFlag(OptimusSettings::TripleBuffer));
 }
 
 void SettingsDialog::on_intelIconButton_clicked()

--- a/src/settingsdialog.ui
+++ b/src/settingsdialog.ui
@@ -770,12 +770,12 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="nvidiaTrippleBuffercheckBox">
+            <widget class="QCheckBox" name="nvidiaTripleBuffercheckBox">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable triple buffering&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>Tripple buffer</string>
+              <string>Triple buffer</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
* Fixes #3
* Use `tr().arg()` for better translation