### PR TITLE
Add automatic logout support for Deepin

### DIFF
--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -457,6 +457,9 @@ void OptimusManager::logout()
 
     QDBusInterface xfce("org.xfce.SessionManager", "/org/xfce/SessionManager", "org.xfce.Session.Manager");
     xfce.call("Logout", false, true);
+
+    QDBusInterface deepin("com.deepin.SessionManager", "/com/deepin/SessionManager", "com.deepin.SessionManager");
+    deepin.call("RequestLogout");
 }
 
 QString OptimusManager::gpuString(GPU gpu)


### PR DESCRIPTION
- Currently, optimus-manager only restarts KDE, GNOME and XFCE.
- Get deepin's dbus object and call RequestLogout() to restart the DE.

Test: Switch GPUs; Display Manager restarts and GPU switches correctly.
Sys Config: DeepinDE + LightDM on ArchLinux
  - iGPU: Intel HD 620
  - dGPU: NVIDIA 940 MX

Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>