### PR TITLE
Remove extra quotes preventing awesome.quit()

### DIFF
--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -523,7 +523,7 @@ void OptimusManager::logout()
     if (QProcess::execute(QStringLiteral("openbox"), {QStringLiteral("--exit")}) == 0)
         return;
 
-    if (QProcess::execute(QStringLiteral("awesome-client"), {QStringLiteral("\"awesome.quit()\"")}) == 0)
+    if (QProcess::execute(QStringLiteral("awesome-client"), {QStringLiteral("awesome.quit()")}) == 0)
         return;
 
     if (QProcess::execute(QStringLiteral("bspc"), {QStringLiteral("quit")}) == 0)


### PR DESCRIPTION
Without this awesome-client would just spit out this:

`   string "[string ""awesome.quit()""]:1: unexpected symbol near '"awesome.quit()"'"`