### PR TITLE
Fixed integrated amd gpu detection

### DIFF
--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -404,7 +404,7 @@ AppSettings::Gpu OptimusManager::detectGpu()
     const QByteArray gpuName = QByteArray::fromRawData(providerInfo->name, qstrlen(providerInfo->name));
     if (gpuName.startsWith("Intel"))
         return AppSettings::IntelGpu;
-    if (gpuName.startsWith("Unknown AMD Radeon GPU"))
+    if (gpuName.startsWith("Unknown AMD Radeon GPU") || gpuName.startsWith("AMD"))
         return AppSettings::AmdGpu;
     if (gpuName.startsWith("NVIDIA"))
         return AppSettings::NvidiaGpu;


### PR DESCRIPTION
Recently I've done update of my manjaro and optimus-manager-qt can't start anymore with error "Unable to detect gpu". I've done some debugging and found that in `gpuName` string now I have `"AMD Radeon(TM) Vega 10 Graphics @ pci:0000:05:00.0"` which is not matches condition 
```
gpuName.startsWith("Unknown AMD Radeon GPU")
```
My commit fixes this case.