### PR TITLE
Change plasma logout service call from "ksmserver" to "Shutdown"

### DIFF
--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -476,8 +476,9 @@ int OptimusManager::sessionsCountWithoutGdm(const QVector<Session> &sessions)
 
 void OptimusManager::logout()
 {
-    QDBusInterface kde(QStringLiteral("org.kde.Shutdown"), QStringLiteral("/Shutdown"));
-    if (kde.call(QStringLiteral("logout")).type() == QDBusMessage::ReplyMessage)
+    QDBusInterface kde5(QStringLiteral("org.kde.ksmserver"), QStringLiteral("/KSMServer"), QStringLiteral("org.kde.KSMServerInterface"));
+    QDBusInterface kde6(QStringLiteral("org.kde.Shutdown"), QStringLiteral("/Shutdown"));
+    if (kde6.call(QStringLiteral("logout")).type() == QDBusMessage::ReplyMessage || kde5.call(QStringLiteral("logout"), 0, 3, 3).type() == QDBusMessage::ReplyMessage)
         return;
 
     QDBusInterface gnome(QStringLiteral("org.gnome.SessionManager"), QStringLiteral("/org/gnome/SessionManager"), QStringLiteral("org.gnome.SessionManager"));

--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -476,9 +476,12 @@ int OptimusManager::sessionsCountWithoutGdm(const QVector<Session> &sessions)
 
 void OptimusManager::logout()
 {
-    QDBusInterface kde5(QStringLiteral("org.kde.ksmserver"), QStringLiteral("/KSMServer"), QStringLiteral("org.kde.KSMServerInterface"));
     QDBusInterface kde6(QStringLiteral("org.kde.Shutdown"), QStringLiteral("/Shutdown"));
-    if (kde6.call(QStringLiteral("logout")).type() == QDBusMessage::ReplyMessage || kde5.call(QStringLiteral("logout"), 0, 3, 3).type() == QDBusMessage::ReplyMessage)
+    if (kde6.call(QStringLiteral("logout")).type() == QDBusMessage::ReplyMessage)
+        return;
+
+    QDBusInterface kde5(QStringLiteral("org.kde.ksmserver"), QStringLiteral("/KSMServer"), QStringLiteral("org.kde.KSMServerInterface"));
+    if (kde5.call(QStringLiteral("logout"), 0, 3, 3).type() == QDBusMessage::ReplyMessage)
         return;
 
     QDBusInterface gnome(QStringLiteral("org.gnome.SessionManager"), QStringLiteral("/org/gnome/SessionManager"), QStringLiteral("org.gnome.SessionManager"));

--- a/src/optimusmanager.cpp
+++ b/src/optimusmanager.cpp
@@ -476,8 +476,8 @@ int OptimusManager::sessionsCountWithoutGdm(const QVector<Session> &sessions)
 
 void OptimusManager::logout()
 {
-    QDBusInterface kde(QStringLiteral("org.kde.ksmserver"), QStringLiteral("/KSMServer"), QStringLiteral("org.kde.KSMServerInterface"));
-    if (kde.call(QStringLiteral("logout"), 0, 3, 3).type() == QDBusMessage::ReplyMessage)
+    QDBusInterface kde(QStringLiteral("org.kde.Shutdown"), QStringLiteral("/Shutdown"));
+    if (kde.call(QStringLiteral("logout")).type() == QDBusMessage::ReplyMessage)
         return;
 
     QDBusInterface gnome(QStringLiteral("org.gnome.SessionManager"), QStringLiteral("/org/gnome/SessionManager"), QStringLiteral("org.gnome.SessionManager"));


### PR DESCRIPTION
After the plasma 6 update, the autologout function no longer works anymore, the detail issue i've already explained here :
[https://github.com/Askannz/optimus-manager/pull/575](https://github.com/Askannz/optimus-manager/pull/575)

Anyway i've tested this commit and it works great and fixed the issue.